### PR TITLE
fix: ドアの弧の線幅が高ズーム時に太くなるバグを修正

### DIFF
--- a/src/wall-object.ts
+++ b/src/wall-object.ts
@@ -5,8 +5,6 @@ const WINDOW_DRAW_OFFSET = 4;
 const WALL_OBJECT_HIT_TOLERANCE = 6;
 /** Door arc line width (px, before zoom scaling). Thinner than walls for visual distinction. */
 const DOOR_ARC_LINE_WIDTH = 0.8;
-/** Minimum arc line width (px) to keep arcs visible at high zoom levels. */
-const DOOR_ARC_MIN_LINE_WIDTH = 0.3;
 /** Door arc color in default (non-selected, non-active) state. */
 const DOOR_ARC_DEFAULT_COLOR = '#888';
 /** Resize handle diameter (px). */
@@ -242,7 +240,7 @@ function drawDoor(
   ctx.save();
   const arcColor = isActive || isSelected ? color : DOOR_ARC_DEFAULT_COLOR;
   ctx.strokeStyle = arcColor;
-  ctx.lineWidth = Math.max(DOOR_ARC_MIN_LINE_WIDTH, DOOR_ARC_LINE_WIDTH / zoom);
+  ctx.lineWidth = DOOR_ARC_LINE_WIDTH / zoom;
   ctx.beginPath();
   ctx.arc(hingeX, hingeY, radius, closedAngle, openAngle, anticlockwise);
   ctx.stroke();


### PR DESCRIPTION
## Summary

- ドアの弧(arc)の線幅が高ズーム時にスクリーン上で太くなるバグを修正
- `Math.max(MIN, lineWidth/zoom)` の最小値フロアを削除し、`lineWidth/zoom` のみに変更
- PR #20 のレビュー指摘（zoom=10でスクリーン換算3.0pxになる問題）への対応

## Test plan

- [ ] zoom=1 でドアの弧が薄く細い線で表示されること
- [ ] 高ズーム（zoom=5, 10）でも弧の太さがスクリーン上で一定（約0.8px）であること
- [ ] 低ズーム（zoom=0.5）でも弧が正常に表示されること
- [ ] 選択状態・アクティブ状態で弧の色がハイライトカラーに変わること
