### PR TITLE
chore: Prettierフォーマット適用

### DIFF
--- a/src/ProjectListModal.tsx
+++ b/src/ProjectListModal.tsx
@@ -32,10 +32,7 @@ export default function ProjectListModal({
   onDelete,
   onClose,
 }: ProjectListModalProps) {
-  const sorted = useMemo(
-    () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt),
-    [projects],
-  );
+  const sorted = useMemo(() => [...projects].sort((a, b) => b.updatedAt - a.updatedAt), [projects]);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -72,7 +69,11 @@ export default function ProjectListModal({
                     <>
                       {p.name}
                       {isOpen && (
-                        <Chip label="開いている" size="small" sx={{ ml: 1, height: 18, fontSize: 10 }} />
+                        <Chip
+                          label="開いている"
+                          size="small"
+                          sx={{ ml: 1, height: 18, fontSize: 10 }}
+                        />
                       )}
                     </>
                   }

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -85,10 +85,20 @@ export default function TabBar({
           </div>
         ))}
       </div>
-      <button style={addButtonStyle} onClick={onTabAdd} title="新規プロジェクト" aria-label="新規プロジェクト">
+      <button
+        style={addButtonStyle}
+        onClick={onTabAdd}
+        title="新規プロジェクト"
+        aria-label="新規プロジェクト"
+      >
         +
       </button>
-      <button style={listButtonStyle} onClick={onOpenProjectList} title="プロジェクト一覧" aria-label="プロジェクト一覧">
+      <button
+        style={listButtonStyle}
+        onClick={onOpenProjectList}
+        title="プロジェクト一覧"
+        aria-label="プロジェクト一覧"
+      >
         ☰
       </button>
     </div>

--- a/src/camera.test.ts
+++ b/src/camera.test.ts
@@ -257,13 +257,7 @@ describe('hitCameraHandleInRooms', () => {
     const handles1 = getCameraHandlePositions(room, cam1);
 
     // cam1のハンドル位置だがactiveIdがcam-2なのでヒットしない
-    const result = hitCameraHandleInRooms(
-      [room],
-      handles1.rotate.x,
-      handles1.rotate.y,
-      1,
-      'cam-2',
-    );
+    const result = hitCameraHandleInRooms([room], handles1.rotate.x, handles1.rotate.y, 1, 'cam-2');
     expect(result).toBeNull();
   });
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -40,10 +40,7 @@ export function createSecurityCamera(
 }
 
 /** カメラアイコンのピクセル中心座標を計算 */
-export function cameraCenter(
-  room: Room,
-  cam: SecurityCamera,
-): { cx: number; cy: number } {
+export function cameraCenter(room: Room, cam: SecurityCamera): { cx: number; cy: number } {
   return {
     cx: (room.x + cam.x + cam.w / 2) * GRID,
     cy: (room.y + cam.y + cam.h / 2) * GRID,
@@ -186,12 +183,7 @@ export function drawCameraHandles(
   drawDiamond(ctx, handles.fovAngleRight.x, handles.fovAngleRight.y, size);
 }
 
-function drawDiamond(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  size: number,
-): void {
+function drawDiamond(ctx: CanvasRenderingContext2D, x: number, y: number, size: number): void {
   const hs = size / 2;
   ctx.beginPath();
   ctx.moveTo(x, y - hs);

--- a/src/editor/utils.ts
+++ b/src/editor/utils.ts
@@ -5,10 +5,7 @@ import type { ViewportState } from '../viewport.ts';
 
 /** CJK文字を2カラム換算した表示幅をグリッド単位で返す */
 export function labelDisplayWidth(label: string): number {
-  const cols = [...label].reduce(
-    (n, c) => n + (/[\u3000-\u9fff\uff00-\uffef]/.test(c) ? 2 : 1),
-    0,
-  );
+  const cols = [...label].reduce((n, c) => n + (/[\u3000-\u9fff\uff00-\uffef]/.test(c) ? 2 : 1), 0);
   return Math.ceil(cols / 2) + 1;
 }
 

--- a/src/link.ts
+++ b/src/link.ts
@@ -110,10 +110,7 @@ export function linkGroupColor(groupId: string): string {
 }
 
 /** 選択中の部屋の linkGroup に属する全部屋IDと色のマップを返す */
-export function getLinkedIndicators(
-  rooms: Room[],
-  selection: Set<string>,
-): Map<string, string> {
+export function getLinkedIndicators(rooms: Room[], selection: Set<string>): Map<string, string> {
   const result = new Map<string, string>();
   const groups = collectLinkedGroups(rooms, selection);
   if (groups.size === 0) return result;

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -324,18 +324,14 @@ describe('ensureInteriorObjectIds', () => {
   });
 
   it('カメラのfovAngleがクランプされる', () => {
-    const raw = [
-      { type: 'camera', x: 0, y: 0, w: 1, h: 1, fovAngle: 999 },
-    ];
+    const raw = [{ type: 'camera', x: 0, y: 0, w: 1, h: 1, fovAngle: 999 }];
     const result = ensureInteriorObjectIds(raw);
     const cam = result[0] as SecurityCamera;
     expect(cam.fovAngle).toBeCloseTo(Math.PI / 2);
   });
 
   it('カメラのfovRangeがクランプされる', () => {
-    const raw = [
-      { type: 'camera', x: 0, y: 0, w: 1, h: 1, fovRange: 100 },
-    ];
+    const raw = [{ type: 'camera', x: 0, y: 0, w: 1, h: 1, fovRange: 100 }];
     const result = ensureInteriorObjectIds(raw);
     const cam = result[0] as SecurityCamera;
     expect(cam.fovRange).toBe(20);

--- a/src/room.ts
+++ b/src/room.ts
@@ -212,12 +212,7 @@ export function computeGroupBoundingBox(rooms: Room[]): {
 }
 
 /** グループBBの4隅ハンドルをピクセル座標で返す */
-export function getGroupHandles(bb: {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}): GroupHandle[] {
+export function getGroupHandles(bb: { x: number; y: number; w: number; h: number }): GroupHandle[] {
   const x = bb.x * GRID,
     y = bb.y * GRID,
     w = bb.w * GRID,


### PR DESCRIPTION
## Summary

- Prettierによるコードフォーマット適用（機能変更なし）
- 関数シグネチャ・JSX属性・テストコードの改行スタイル統一

## Test plan

- [ ] `npm run format:check` がパスすることを確認
- [ ] `npm test` が全テストパスすることを確認
