### PR TITLE
fix: window.confirm()をMUI Dialogに置き換え

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const deleteTargetIdRef = useRef<string | null>(null);
-  const deleteTargetNameRef = useRef<string>('');
+  const [deleteTargetName, setDeleteTargetName] = useState('');
 
   const handleRoomEdit = useCallback(
     (data: RoomEditData): Promise<{ label: string; fontSize?: number } | null> => {
@@ -420,7 +420,7 @@ export default function App() {
       const index = loadProjectIndex();
       if (index.length <= 1) return;
       deleteTargetIdRef.current = id;
-      deleteTargetNameRef.current = index.find((m) => m.id === id)?.name ?? '';
+      setDeleteTargetName(index.find((m) => m.id === id)?.name ?? '');
       setDeleteConfirmOpen(true);
     },
     [],
@@ -458,7 +458,7 @@ export default function App() {
 
   const handleDeleteConfirmExited = useCallback(() => {
     deleteTargetIdRef.current = null;
-    deleteTargetNameRef.current = '';
+    setDeleteTargetName('');
   }, []);
 
   const handleDuplicateProject = useCallback(
@@ -796,8 +796,7 @@ export default function App() {
         <DialogTitle>プロジェクトの削除</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            プロジェクト「{deleteTargetNameRef.current}
-            」を削除しますか？この操作は取り消せません。
+            プロジェクト「{deleteTargetName}」を削除しますか？この操作は取り消せません。
           </DialogContentText>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
## Summary

- `window.confirm()` をMUI `Dialog` ベースの非同期確認ダイアログに置き換え
- ダークテーマとの統一性を改善し、UIスレッドのブロックを解消
- 削除対象のプロジェクト名をダイアログに表示して誤削除を防止
- `deleteTargetId` を `useRef` で管理（`tabStateRef` と同パターン）

## Test plan

- [x] typecheck パス
- [x] lint パス（warning 0、既存の unused eslint-disable warning のみ）
- [x] 全442テストパス
- [ ] プロジェクト一覧から削除ボタン → ダイアログ表示、プロジェクト名が正しく表示される
- [ ] キャンセルで削除されない
- [ ] 削除ボタンで正常に削除される
- [ ] ESCキー、バックドロップクリックでキャンセルされる
- [ ] 最後のプロジェクトでは削除ボタンが反応しない（既存動作維持）

Closes #39
