### PR TITLE
test: project-storeのテストカバレッジ強化

### DIFF
--- a/src/project-store.test.ts
+++ b/src/project-store.test.ts
@@ -665,4 +665,19 @@ describe('loadProjectData viewport edge cases', () => {
     const result = loadProjectData('vp4');
     expect(result!.data.viewport.zoom).toBe(MAX_ZOOM);
   });
+
+  it('falls back to full default when zoom is Infinity (serialized as null)', () => {
+    // JSON.stringify({ zoom: Infinity }) → { zoom: null } — typeof null !== 'number' なので全体フォールバック
+    storage.set(
+      'yakata_project_vp5',
+      JSON.stringify({
+        rooms: [],
+        freeTexts: [],
+        viewport: { zoom: Infinity, panX: 100, panY: 200 },
+      }),
+    );
+    const result = loadProjectData('vp5');
+    // zoom が null になるため parseViewport の typeof チェックで弾かれ、panX/panY も含め全体がデフォルトに
+    expect(result!.data.viewport).toEqual({ zoom: 1, panX: 0, panY: 0 });
+  });
 });


### PR DESCRIPTION
## Summary

- project-store.tsのテストを24件追加（30件 → 54件）
- deduplicateName edge cases、タブ切替の状態分離、リネーム境界値、loadProjectData warning/viewport、deleteProject/touchProjectUpdatedAt edge cases、migrateIfNeeded追加ケースをカバー
- emptyProjectData()ヘルパーでテストデータの重複を解消

## Test plan

- [x] typecheck パス
- [x] lint パス
- [x] 全466テストパス（既存442 + 新規24）

Closes #40
